### PR TITLE
Fixes to make script work with latest julia version

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,12 +14,14 @@ HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
 XLSX = "fdbf4ff8-1666-58a4-91e7-1b58723a45e0"
 
 [compat]
-ArgParse = "1.1"
-CurrencyAmounts = "0.1"
-DataFrames = "0.22, 1"
-FixedPointDecimals = "0.3"
-HTTP = "0.9"
-XLSX = "0.7"
+ArgParse = "1.2.0"
+CurrencyAmounts = "0.1.2"
+DataFrames = "1.7.0"
+Dates = "1.11.0"
+DelimitedFiles = "1.9.1"
+FixedPointDecimals = "0.5.3"
+HTTP = "1.10.8"
+XLSX = "0.10.4"
 julia = "1"
 
 [extras]

--- a/src/CGT.jl
+++ b/src/CGT.jl
@@ -64,7 +64,7 @@ function period(c::Currency, df::AbstractDataFrame; details=false)
 	cols = propertynames(df)
 
 	if details
-		show(df; allrows=true, allcols=true, summary=false, eltypes=false, show_row_number=false, vlines=:all, newline_at_end=true, hlines=[:begin, :header, :end], filters_col=((_, i) -> cols[i] != :Late,))
+		show(df; allrows=true, allcols=true, summary=false, eltypes=false, show_row_number=false, vlines=:all, newline_at_end=true, hlines=[:begin, :header, :end])
 	end
 	println("Gain/Loss: ", gain)
 	println("Tax: ", max(0c, gain) * Tax)

--- a/src/CGT.jl
+++ b/src/CGT.jl
@@ -21,7 +21,7 @@ end
 ExchangeRates(::From, ::To) where {From <: Currency, To <: Currency} = ExchangeRates{From, To}(Dict())
 
 function fetch(date, from, to)
-	url = "https://sdw-wsrest.ecb.europa.eu/service/data/EXR/D.$from.$to.SP00.A?detail=dataonly&startPeriod=$date&endPeriod=$date"
+	url = "https://data-api.ecb.europa.eu/service/data/EXR/D.$from.$to.SP00.A?detail=dataonly&startPeriod=$date&endPeriod=$date"
 	(data, header) = readdlm(HTTP.get(url, ["Accept" => "text/csv"]).body, ','; header=true)
 	Fixed(data[findfirst(isequal("OBS_VALUE"), header)])
 end

--- a/src/CGT.jl
+++ b/src/CGT.jl
@@ -51,7 +51,7 @@ function load(file)
 	fmt = DateFormat("m/d/y")
 	to_usd(s) = Fixed(s)*USD
 
-	df = DataFrame(XLSX.gettable(XLSX.readxlsx(file)[1])...)
+	df = DataFrame(XLSX.readtable(file, "G&L_Expanded"))
 	filter!("Record Type" => isequal("Sell"), df)
 	select!(df, "Date Sold" => ByRow(d -> Date(d, fmt)) => "Date", "Plan Type" => "Type", "Total Proceeds" => ByRow(to_usd) => "Proceeds", "Adjusted Gain/Loss" => ByRow(to_usd) => "Gains")
 	sort!(df, :Date)


### PR DESCRIPTION
* [Update currency exchange API URL](https://github.com/wladh/CGT.jl/commit/f3987779c170815a6558fd631e3dc43e8da36d31)

Per https://data.ecb.europa.eu/help/api/overview
the currency exchange API has been migrated from
https://sdw-wsrest.ecb.europa.eu/ to
https://data-api.ecb.europa.eu/

* [Upgrade dependencies](https://github.com/wladh/CGT.jl/commit/423750406e36abeef4e64c7c33d408f4196e3cf3)

The program was broken on julia 1.11.1 due to
old HTTP dependency that breaks in newer
julia versions. See
https://github.com/JuliaWeb/HTTP.jl/issues/1157

* [Fix XLSX to DataFrame conversion](https://github.com/wladh/CGT.jl/commit/9dd54159887b7e2a491fb31ab415fb1803b8989d)

It was failing due to dependency upgrade
See https://discourse.julialang.org/t/error-reading-an-xlsx-file/85352/2

* [Fix verbose mode print](https://github.com/wladh/CGT.jl/commit/29fb347aa50fa44f8df1abbda2c7004d93d492d3)

Without this change get error:
got unsupported keyword argument "filters_col"